### PR TITLE
Fix: Allow all valid SMB share name characters

### DIFF
--- a/source/usr/local/emhttp/plugins/custom.smb.shares/include/ConfigRegistry.php
+++ b/source/usr/local/emhttp/plugins/custom.smb.shares/include/ConfigRegistry.php
@@ -27,7 +27,7 @@ declare(strict_types=1);
 class ConfigRegistry
 {
     // Validation patterns
-    public const SHARE_NAME_PATTERN = '/^[a-zA-Z0-9_-]+$/';
+    public const SHARE_NAME_PATTERN = '/^\s+|\s+$|[\x00-\x1F\x7F\[\]"\/\\\\:;|<>,\?\*=]/u';
     public const OCTAL_MASK_PATTERN = '/^[0-7]{4}$/';
     public const PATH_PREFIX = '/mnt/';
     public const BACKUP_FILENAME_PATTERN = '/^shares_[\d_-]+\.json$/';

--- a/source/usr/local/emhttp/plugins/custom.smb.shares/include/lib.php
+++ b/source/usr/local/emhttp/plugins/custom.smb.shares/include/lib.php
@@ -68,8 +68,8 @@ function validateShare(array &$data): array
 {
     $errors = [];
 
-    if (empty($data['name']) || !preg_match(ConfigRegistry::SHARE_NAME_PATTERN, $data['name'])) {
-        $errors[] = 'Invalid share name. Use only letters, numbers, hyphens, and underscores.';
+    if (empty($data['name']) || preg_match(ConfigRegistry::SHARE_NAME_PATTERN, $data['name'])) {
+        $errors[] = 'Invalid share name. Shares cannot contain [ ] " / \ : ; | < > , ? * = characters.';
     }
 
     $pathPattern = TestModeDetector::getPathPattern();


### PR DESCRIPTION
Only characters disallowed in SMB are [ ] " / \ : ; | < > , ? * =