### PR TITLE
Fix switch initialization state

### DIFF
--- a/source/usr/local/emhttp/plugins/custom.smb.shares/SMBShares.page
+++ b/source/usr/local/emhttp/plugins/custom.smb.shares/SMBShares.page
@@ -173,8 +173,7 @@ $(function() {
     // Initialize toggle switches
     $('.share-toggle').switchButton({
         on_label: '',
-        off_label: '',
-        checked: function() { return $(this).is(':checked'); }
+        off_label: ''
     }).on('change', function() {
         var $toggle = $(this);
         var shareName = $toggle.data('share');


### PR DESCRIPTION
## Fix switch initialization state

### Summary

Remove the custom `checked` callback from the `switchButton()` initialization.

### Problem

The toggle switch could display an incorrect visual state after the page loaded or was refreshed. The underlying checkbox state was correct, but the switch widget did not consistently reflect that state until a subsequent page refresh.

### Cause

The switch was initialized with:

```javascript
checked: function() {
	return $(this).is(':checked');
}
```

The `switchButton` widget expects the initial checkbox state to come from the checkbox itself, not from a callback. Removing the callback allows the widget to correctly initialize from the existing `checked` attribute.

### Result

* Toggle switches now consistently display the correct initial state.
* No functional changes to the enable/disable logic.
* Existing AJAX behavior is unchanged.