### PR TITLE
Disable Custom SMB Shares page when the array is stopped

### DIFF
--- a/source/usr/local/emhttp/plugins/custom.smb.shares/SMBShares.page
+++ b/source/usr/local/emhttp/plugins/custom.smb.shares/SMBShares.page
@@ -44,6 +44,7 @@ $sambaRunning = $sambaStatus['running'];
 .feature-icons i[title] { cursor: help; }
 </style>
 
+<?php if ($var['mdState']=="STARTED"):?>
 <?php if (!$pluginEnabled): ?>
 <div class="disabled-banner">
     <i class="fa fa-exclamation-triangle"></i>
@@ -152,6 +153,9 @@ $sambaRunning = $sambaStatus['running'];
 </tbody>
 </table>
 </div>
+<?else:?>
+	<p>_(Array is stopped)_!</p>
+<?endif;?>
 
 <div style="display:flex;justify-content:flex-end;margin-top:12px;">
     <input type="button" value="_(Add Share)_" onclick="location.href='/SMBSharesAdd'">


### PR DESCRIPTION
## Disable the Custom SMB Shares page when the array is stopped

This change prevents the Custom SMB Shares management page from being displayed while the array is stopped.

### Changes

* Display the Custom SMB Shares interface only when `mdState == "STARTED"`.
* Show an informational message when the array is stopped.

### Why

Custom SMB Shares are only available while the array is running. Disabling the management interface when the array is stopped avoids presenting controls that cannot be used and provides a clearer user experience.