### PR TITLE
Add Recycle Bin Next support for Custom SMB Shares

### DIFF
--- a/source/usr/local/emhttp/plugins/custom.smb.shares/include/lib.php
+++ b/source/usr/local/emhttp/plugins/custom.smb.shares/include/lib.php
@@ -916,10 +916,30 @@ function reloadSamba(): array
         return ['success' => false, 'error' => 'Invalid Samba configuration: ' . implode("\n", $output)];
     }
 
-    exec(escapeshellarg($smbcontrol) . " all reload-config 2>&1", $output, $ret);
-    if ($ret !== 0) {
-        return ['success' => false, 'error' => implode("\n", $output)];
-    }
+	/* Restart the recycle bin to adjust for changes. */
+	/* If the recycle bin plugin is installed and running, reload the recycle bin. */
+	$recycle_script = "/usr/local/emhttp/plugins/recycle.bin/scripts/rc.recycle.bin";
+
+	if ((is_executable($recycle_script)) && (is_file("/var/run/recycle.bin.pid"))) {
+		/* The recycle bin will reload samba. */
+
+		$output = [];
+		exec(escapeshellarg($recycle_script)." reload 2>&1", $output, $ret);
+
+		if ($ret !== 0) {
+			return ['success' => false, 'error' => implode("\n", $output)];
+		}
+	} else {
+		/* If there is no recycle bin, then just reload samba. */
+
+		$output = [];
+		exec(escapeshellarg($smbcontrol)." all reload-config 2>&1", $output, $ret);
+
+		if ($ret !== 0) {
+			return ['success' => false, 'error' => implode("\n", $output)];
+		}
+	}
+
     return ['success' => true, 'error' => ''];
 }
 


### PR DESCRIPTION
## Add Recycle Bin Next support for Custom SMB Shares

This PR adds integration with **Recycle Bin Next** for Custom SMB Shares.

### Changes

* Detect and manage Custom SMB Shares when Recycle Bin Next starts and stops.
* Monitor Custom SMB Shares for changes and automatically update recycle bin monitoring as shares are added, modified, or removed.
* Create and remove recycle bin monitoring for Custom SMB Shares using the same behavior as standard SMB shares.
* Ensure cleanup occurs during array shutdown to avoid stale monitoring.

### Why

This integration allows Custom SMB Shares to work seamlessly with **Recycle Bin Next**, providing the same recycle bin functionality available for standard SMB shares without requiring additional configuration.

The implementation extends the existing Recycle Bin Next architecture while preserving the behavior of Custom SMB Shares.