### PR TITLE
Add plugin README.md file.

### DIFF
--- a/source/usr/local/emhttp/plugins/custom.smb.shares/README.md
+++ b/source/usr/local/emhttp/plugins/custom.smb.shares/README.md
@@ -1,0 +1,9 @@
+**Custom SMB Shares**
+
+Create and manage custom Samba/SMB shares with advanced configuration options not available in Unraid's built-in share system.
+
+Custom SMB Shares support the same access controls as standard SMB shares and are managed through the Unraid web interface.
+
+When Recycle Bin - Next is installed, custom shares automatically use the recycle bin of their parent Unraid user share.
+
+SMB shares within Unraid user shares are supported with a Recycle Bin.


### PR DESCRIPTION
## Summary

Add a `README.md` for the Custom SMB Shares plugin to provide a brief description of the plugin that is displayed on the plugin installation page.

## Details

The README explains the purpose of the plugin, describes its basic functionality, and notes compatibility with Recycle Bin - Next when installed. It also clarifies that recycle bin support applies to custom SMB shares created within Unraid user shares.

This change is documentation only and does not modify plugin functionality.